### PR TITLE
feat: add MiniMax as a built-in LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pip install -e ".[evolve]"  # + skill evolution via OpenAI-compatible LLM
 metaclaw setup
 ```
 
-The interactive wizard will ask you to choose your LLM provider (Kimi, Qwen, or custom), enter your API key, and optionally enable RL training.
+The interactive wizard will ask you to choose your LLM provider (Kimi, Qwen, MiniMax, or custom), enter your API key, and optionally enable RL training.
 
 ### 3. Start
 
@@ -156,7 +156,7 @@ Configuration lives in `~/.metaclaw/config.yaml`, created by `metaclaw setup`.
 mode: skills_only          # "skills_only" | "rl"
 
 llm:
-  provider: kimi            # kimi | qwen | openai | custom
+  provider: kimi            # kimi | qwen | openai | minimax | custom
   model_id: moonshotai/Kimi-K2.5
   api_base: https://api.moonshot.cn/v1
   api_key: sk-...

--- a/assets/README_DE.md
+++ b/assets/README_DE.md
@@ -115,7 +115,7 @@ pip install -e ".[evolve]"  # + Skill-Evolution via OpenAI-kompatibler LLM
 metaclaw setup
 ```
 
-Der interaktive Assistent führt dich durch die Auswahl des LLM-Anbieters (Kimi, Qwen oder benutzerdefiniert), API-Schlüssel und optionale RL-Aktivierung.
+Der interaktive Assistent führt dich durch die Auswahl des LLM-Anbieters (Kimi, Qwen, MiniMax oder benutzerdefiniert), API-Schlüssel und optionale RL-Aktivierung.
 
 ### 3. Start
 
@@ -158,7 +158,7 @@ Die Konfiguration liegt in `~/.metaclaw/config.yaml`, erstellt durch `metaclaw s
 mode: skills_only          # "skills_only" | "rl"
 
 llm:
-  provider: kimi            # kimi | qwen | openai | custom
+  provider: kimi            # kimi | qwen | openai | minimax | custom
   model_id: moonshotai/Kimi-K2.5
   api_base: https://api.moonshot.cn/v1
   api_key: sk-...

--- a/assets/README_ES.md
+++ b/assets/README_ES.md
@@ -115,7 +115,7 @@ pip install -e ".[evolve]"  # + evolución de skills via LLM compatible con Open
 metaclaw setup
 ```
 
-El asistente interactivo te pedirá que elijas tu proveedor de LLM (Kimi, Qwen o personalizado), tu clave API y si deseas activar el entrenamiento RL.
+El asistente interactivo te pedirá que elijas tu proveedor de LLM (Kimi, Qwen, MiniMax o personalizado), tu clave API y si deseas activar el entrenamiento RL.
 
 ### 3. Inicio
 
@@ -158,7 +158,7 @@ La configuración se encuentra en `~/.metaclaw/config.yaml`, creada por `metacla
 mode: skills_only          # "skills_only" | "rl"
 
 llm:
-  provider: kimi            # kimi | qwen | openai | custom
+  provider: kimi            # kimi | qwen | openai | minimax | custom
   model_id: moonshotai/Kimi-K2.5
   api_base: https://api.moonshot.cn/v1
   api_key: sk-...

--- a/assets/README_FR.md
+++ b/assets/README_FR.md
@@ -115,7 +115,7 @@ pip install -e ".[evolve]"  # + évolution des skills via LLM compatible OpenAI
 metaclaw setup
 ```
 
-L'assistant interactif vous demande de choisir votre fournisseur LLM (Kimi, Qwen, ou personnalisé), votre clé API, et d'activer optionnellement l'entraînement RL.
+L'assistant interactif vous demande de choisir votre fournisseur LLM (Kimi, Qwen, MiniMax, ou personnalisé), votre clé API, et d'activer optionnellement l'entraînement RL.
 
 ### 3. Démarrage
 
@@ -158,7 +158,7 @@ La configuration se trouve dans `~/.metaclaw/config.yaml`, créée par `metaclaw
 mode: skills_only          # "skills_only" | "rl"
 
 llm:
-  provider: kimi            # kimi | qwen | openai | custom
+  provider: kimi            # kimi | qwen | openai | minimax | custom
   model_id: moonshotai/Kimi-K2.5
   api_base: https://api.moonshot.cn/v1
   api_key: sk-...

--- a/assets/README_JA.md
+++ b/assets/README_JA.md
@@ -115,7 +115,7 @@ pip install -e ".[evolve]"  # + OpenAI 互換 LLM によるスキル進化
 metaclaw setup
 ```
 
-対話型ウィザードで LLM プロバイダー（Kimi、Qwen、またはカスタム）、API キー、RL の有効化を設定します。
+対話型ウィザードで LLM プロバイダー（Kimi、Qwen、MiniMax、またはカスタム）、API キー、RL の有効化を設定します。
 
 ### 3. 起動
 
@@ -158,7 +158,7 @@ metaclaw config proxy.port 31000          # プロキシポートを変更
 mode: skills_only          # "skills_only" | "rl"
 
 llm:
-  provider: kimi            # kimi | qwen | openai | custom
+  provider: kimi            # kimi | qwen | openai | minimax | custom
   model_id: moonshotai/Kimi-K2.5
   api_base: https://api.moonshot.cn/v1
   api_key: sk-...

--- a/assets/README_KO.md
+++ b/assets/README_KO.md
@@ -115,7 +115,7 @@ pip install -e ".[evolve]"  # + OpenAI 호환 LLM을 통한 스킬 진화
 metaclaw setup
 ```
 
-대화형 마법사에서 LLM 공급자(Kimi, Qwen, 또는 커스텀), API 키, RL 활성화 여부를 설정합니다.
+대화형 마법사에서 LLM 공급자(Kimi, Qwen, MiniMax, 또는 커스텀), API 키, RL 활성화 여부를 설정합니다.
 
 ### 3. 시작
 
@@ -158,7 +158,7 @@ metaclaw config proxy.port 31000          # 프록시 포트 변경
 mode: skills_only          # "skills_only" | "rl"
 
 llm:
-  provider: kimi            # kimi | qwen | openai | custom
+  provider: kimi            # kimi | qwen | openai | minimax | custom
   model_id: moonshotai/Kimi-K2.5
   api_base: https://api.moonshot.cn/v1
   api_key: sk-...

--- a/assets/README_ZH.md
+++ b/assets/README_ZH.md
@@ -115,7 +115,7 @@ pip install -e ".[evolve]"  # + 通过 OpenAI 兼容 LLM 进行 Skill 进化
 metaclaw setup
 ```
 
-交互式向导会引导你选择 LLM 提供商（Kimi、Qwen 或自定义），填写 API Key，并可选开启 RL 训练。
+交互式向导会引导你选择 LLM 提供商（Kimi、Qwen、MiniMax 或自定义），填写 API Key，并可选开启 RL 训练。
 
 ### 3. 启动
 
@@ -158,7 +158,7 @@ metaclaw config proxy.port 31000          # 修改代理端口
 mode: skills_only          # "skills_only" | "rl"
 
 llm:
-  provider: kimi            # kimi | qwen | openai | custom
+  provider: kimi            # kimi | qwen | openai | minimax | custom
   model_id: moonshotai/Kimi-K2.5
   api_base: https://api.moonshot.cn/v1
   api_key: sk-...

--- a/metaclaw/setup_wizard.py
+++ b/metaclaw/setup_wizard.py
@@ -21,6 +21,10 @@ _PROVIDER_PRESETS = {
         "api_base": "https://api.openai.com/v1",
         "model_id": "gpt-4o",
     },
+    "minimax": {
+        "api_base": "https://api.minimax.io/v1",
+        "model_id": "MiniMax-M2.5",
+    },
     "custom": {
         "api_base": "",
         "model_id": "",
@@ -101,7 +105,7 @@ class SetupWizard:
         current_provider = current_llm.get("provider", "custom")
         provider = _prompt_choice(
             "LLM provider",
-            ["kimi", "qwen", "openai", "custom"],
+            ["kimi", "qwen", "openai", "minimax", "custom"],
             default=current_provider,
         )
         preset = _PROVIDER_PRESETS[provider]


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com) as a built-in LLM provider preset in the setup wizard.

MiniMax provides an OpenAI-compatible API (`https://api.minimax.io/v1`) with models like **MiniMax-M2.5** (204K context window). Since MetaClaw already uses OpenAI-compatible forwarding via httpx, MiniMax works seamlessly without any architectural changes.

### Changes

- **`metaclaw/setup_wizard.py`**: Add `minimax` to `_PROVIDER_PRESETS` with `api.minimax.io/v1` as the base URL and `MiniMax-M2.5` as the default model. Add `minimax` to the interactive provider choice list.
- **README files** (EN, ZH, JA, KO, FR, DE, ES): Update provider documentation and config examples to include `minimax`.

### Usage

After this change, users can select MiniMax during setup:

```bash
metaclaw setup
# Select "minimax" as provider → auto-fills API base and model
```

Or configure directly:

```yaml
llm:
  provider: minimax
  model_id: MiniMax-M2.5
  api_base: https://api.minimax.io/v1
  api_key: your-key-here
```

### Testing

- Verified Python syntax and AST parsing of modified `setup_wizard.py`
- Confirmed the minimax preset is correctly added to `_PROVIDER_PRESETS`
- Confirmed the provider choice list includes `minimax`
- No existing tests in the repository; changes are minimal and additive