### PR TITLE
Add configure_openclaw flag for standalone deployment

### DIFF
--- a/metaclaw/config.py
+++ b/metaclaw/config.py
@@ -101,6 +101,7 @@ class MetaClawConfig:
     # "rl"          — v0.2: RL without scheduler (trains immediately on full batch)
     # "skills_only" — proxy + skill injection only (no Tinker, no RL)
     mode: str = "madmax"
+    configure_openclaw: bool = True  # set to False for standalone deployment
 
     # ------------------------------------------------------------------ #
     # Scheduler (meta-learning: gate slow RL updates to idle windows)     #

--- a/metaclaw/config_store.py
+++ b/metaclaw/config_store.py
@@ -23,6 +23,7 @@ _DEFAULTS: dict = {
         "api_key": "",
     },
     "proxy": {"port": 30000, "host": "0.0.0.0", "api_key": ""},
+    "configure_openclaw": True,
     "skills": {
         "enabled": True,
         "dir": str(Path.home() / ".metaclaw" / "skills"),
@@ -149,6 +150,7 @@ class ConfigStore:
         sched = data.get("scheduler", {})
         sched_cal = sched.get("calendar", {})
         mode = data.get("mode", "madmax")
+        configure_openclaw = bool(data.get("configure_openclaw", True))
         rl_enabled = mode in ("rl", "madmax") or bool(rl.get("enabled", False))
 
         # Evolver: prefer rl.evolver_*, fallback to llm.*
@@ -214,6 +216,7 @@ class ConfigStore:
                 sched_cal.get("token_path", "")
                 or str(Path.home() / ".metaclaw" / "calendar_token.json")
             ),
+            configure_openclaw=configure_openclaw,
         )
 
     def describe(self) -> str:

--- a/metaclaw/launcher.py
+++ b/metaclaw/launcher.py
@@ -138,8 +138,9 @@ class MetaClawLauncher:
 
         logger.info("[Launcher] proxy ready at http://%s:%d", cfg.proxy_host, cfg.proxy_port)
 
-        # Configure openclaw to point at the proxy
-        self._configure_openclaw(cfg)
+        # Configure openclaw to point at the proxy (skip for standalone deployments)
+        if cfg.configure_openclaw:
+            self._configure_openclaw(cfg)
 
         # Keep running until stopped
         while not self._stop_event.is_set():
@@ -213,8 +214,9 @@ class MetaClawLauncher:
         )
 
         # Configure openclaw once the proxy is about to be ready
-        await asyncio.sleep(3)
-        self._configure_openclaw(cfg)
+        if cfg.configure_openclaw:
+            await asyncio.sleep(3)
+            self._configure_openclaw(cfg)
 
         tasks = [asyncio.create_task(trainer.run())]
         if scheduler is not None:


### PR DESCRIPTION
 Summary

  - Added configure_openclaw config option (default: true) to MetaClawConfig and config_store.py
  - Gated both _configure_openclaw() calls in launcher.py (skills_only and RL modes) behind this flag
  - When set to false, MetaClaw skips all openclaw config set / openclaw gateway restart subprocess calls at startup

  Motivation

  Previously, MetaClaw always attempted to auto-configure the local OpenClaw instance on startup, making it impossible to deploy MetaClaw on a separate machine from OpenClaw. With this change, MetaClaw can run as a pure OpenAI-compatible HTTP proxy
  without requiring OpenClaw to be installed on the same host.

  Usage

  Set in ~/.metaclaw/config.yaml:

  configure_openclaw: false

  Then configure OpenClaw manually to point at the MetaClaw proxy:

  openclaw config set models.providers.metaclaw --json '{"api": "openai-completions", "baseUrl": "http://<metaclaw-host>:30000/v1", ...}'
  openclaw config set agents.defaults.model.primary metaclaw/<model-id>
  openclaw gateway restart

  Notes

  - Default remains true — existing single-machine setups are unaffected
  - Only launcher.py was modified; _configure_openclaw() itself is unchanged and still available for local deployments
  - In skills_only mode, this was the only place MetaClaw interfered with the OpenClaw instance