### PR TITLE
Fix skills-only custom base URL resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ scheduler:                  # v0.3: meta-learning scheduler (auto-enabled in mad
 
 The lightest mode. No GPU, no RL backend needed. MetaClaw places your LLM behind a proxy that injects relevant skills at every turn, then auto-summarizes new skills after each conversation.
 
+For OpenAI-compatible custom providers, set `llm.api_base` to the full chat API base (usually ending in `/v1`, for example `https://your-gateway.example/v1`). In `skills_only` mode, MetaClaw reuses that same endpoint for prompt compression and related helper LLM calls unless you configure a separate evolver endpoint.
+
 Skills are short Markdown instructions stored in `~/.metaclaw/skills/` as individual `SKILL.md` files. The library grows automatically with your usage.
 
 To pre-load the built-in skill bank (40+ skills across coding, security, agentic tasks, etc.):

--- a/metaclaw/api_server.py
+++ b/metaclaw/api_server.py
@@ -987,11 +987,19 @@ class MetaClawAPIServer:
                         raw_system = _flatten_message_content(m.get("content"))
                         break
                 if raw_system:
-                    cached_system = await asyncio.to_thread(
-                        run_llm,
-                        [{"role": "user", "content": raw_system}],
-                    )
-                    cached_system = (cached_system or raw_system).strip()
+                    try:
+                        cached_system = await asyncio.to_thread(
+                            run_llm,
+                            [{"role": "user", "content": raw_system}],
+                            self.config,
+                        )
+                        cached_system = (cached_system or raw_system).strip()
+                    except Exception as e:
+                        logger.warning(
+                            "[OpenClaw] system prompt compression failed: %s — using raw system prompt",
+                            e,
+                        )
+                        cached_system = raw_system.strip()
                     self._write_cached_system_prompt(cached_system)
 
             if cached_system:

--- a/metaclaw/utils.py
+++ b/metaclaw/utils.py
@@ -1,6 +1,9 @@
-from typing import Any
+from typing import Any, Optional, TYPE_CHECKING
 import os
 import subprocess
+
+if TYPE_CHECKING:
+    from .config import MetaClawConfig
 
 _COMPRESSION_INSTRUCTION = (
     "You are compressing an OpenClaw system prompt. "
@@ -20,15 +23,31 @@ _COMPRESSION_INSTRUCTION = (
 )
 
 
-def _get_llm_provider() -> str:
+def _get_llm_provider(config: Optional["MetaClawConfig"] = None) -> str:
     """Detect whether to use Bedrock or OpenAI based on config/env."""
+    if config is not None:
+        if getattr(config, "mode", "") == "skills_only":
+            if getattr(config, "llm_provider", "") == "bedrock":
+                return "bedrock"
+            return "openai"
+        if getattr(config, "prm_provider", "") == "bedrock":
+            return "bedrock"
+        return "openai"
+
     try:
         from .config_store import ConfigStore
+
         cfg = ConfigStore().load()
         if isinstance(cfg, dict):
-            prm_provider = cfg.get("rl", {}).get("prm_provider", "")
-            if prm_provider == "bedrock":
-                return "bedrock"
+            mode = str(cfg.get("mode", "") or "")
+            if mode == "skills_only":
+                llm_provider = str((cfg.get("llm", {}) or {}).get("provider", "") or "")
+                if llm_provider == "bedrock":
+                    return "bedrock"
+            else:
+                prm_provider = str((cfg.get("rl", {}) or {}).get("prm_provider", "") or "")
+                if prm_provider == "bedrock":
+                    return "bedrock"
     except Exception:
         pass
     if os.environ.get("METACLAW_USE_BEDROCK", "").lower() in ("1", "true", "yes"):
@@ -36,19 +55,26 @@ def _get_llm_provider() -> str:
     return "openai"
 
 
-def run_llm(messages):
-    provider = _get_llm_provider()
+def run_llm(messages, config: Optional["MetaClawConfig"] = None):
+    provider = _get_llm_provider(config)
 
     if provider == "bedrock":
-        return _run_llm_bedrock(messages)
-    return _run_llm_openai(messages)
+        return _run_llm_bedrock(messages, config)
+    return _run_llm_openai(messages, config)
 
 
-def _run_llm_bedrock(messages):
+def _run_llm_bedrock(messages, config: Optional["MetaClawConfig"] = None):
     from .bedrock_client import BedrockChatClient
 
-    model_id = os.environ.get("BEDROCK_MODEL", "us.anthropic.claude-sonnet-4-6")
-    region = os.environ.get("BEDROCK_REGION", "us-east-1")
+    if config is not None and getattr(config, "mode", "") == "skills_only":
+        model_id = config.llm_model_id or os.environ.get(
+            "BEDROCK_MODEL", "us.anthropic.claude-sonnet-4-6"
+        )
+    else:
+        model_id = getattr(config, "prm_model", "") or os.environ.get(
+            "BEDROCK_MODEL", "us.anthropic.claude-sonnet-4-6"
+        )
+    region = getattr(config, "bedrock_region", "") or os.environ.get("BEDROCK_REGION", "us-east-1")
     client = BedrockChatClient(model_id=model_id, region=region)
 
     rewrite_messages = [{"role": "system", "content": _COMPRESSION_INSTRUCTION}, *messages]
@@ -60,7 +86,7 @@ def _run_llm_bedrock(messages):
     return response.choices[0].message.content
 
 
-def _run_llm_openai(messages):
+def _run_llm_openai(messages, config: Optional["MetaClawConfig"] = None):
     try:
         from openai import OpenAI  # optional dep — install with: pip install metaclaw[evolve]
     except ImportError as e:
@@ -68,24 +94,44 @@ def _run_llm_openai(messages):
             "The openai provider requires the 'openai' package. "
             "Install it with: pip install metaclaw[evolve]"
         ) from e
-    prm_url = ""
-    prm_api_key = ""
-    prm_model = ""
-    try:
-        from .config_store import ConfigStore
+    api_base = ""
+    api_key = ""
+    model_id = ""
 
-        cfg = ConfigStore().load()
-        rl_cfg = cfg.get("rl", {}) if isinstance(cfg, dict) else {}
-        if isinstance(rl_cfg, dict):
-            prm_url = str(rl_cfg.get("prm_url", "") or "")
-            prm_api_key = str(rl_cfg.get("prm_api_key", "") or "")
-            prm_model = str(rl_cfg.get("prm_model", "") or "")
-    except Exception:
-        pass
+    if config is not None:
+        if getattr(config, "mode", "") == "skills_only":
+            api_base = getattr(config, "llm_api_base", "") or ""
+            api_key = getattr(config, "llm_api_key", "") or ""
+            model_id = getattr(config, "llm_model_id", "") or ""
+        else:
+            api_base = getattr(config, "prm_url", "") or ""
+            api_key = getattr(config, "prm_api_key", "") or ""
+            model_id = getattr(config, "prm_model", "") or ""
+    else:
+        try:
+            from .config_store import ConfigStore
 
-    api_key = prm_api_key or os.environ.get("OPENAI_API_KEY", "")
-    base_url = prm_url or os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-    model_id = prm_model or os.environ.get("PRM_MODEL", "gpt-5.2")
+            cfg = ConfigStore().load()
+            if isinstance(cfg, dict):
+                mode = str(cfg.get("mode", "") or "")
+                if mode == "skills_only":
+                    llm_cfg = cfg.get("llm", {}) or {}
+                    if isinstance(llm_cfg, dict):
+                        api_base = str(llm_cfg.get("api_base", "") or "")
+                        api_key = str(llm_cfg.get("api_key", "") or "")
+                        model_id = str(llm_cfg.get("model_id", "") or "")
+                else:
+                    rl_cfg = cfg.get("rl", {}) or {}
+                    if isinstance(rl_cfg, dict):
+                        api_base = str(rl_cfg.get("prm_url", "") or "")
+                        api_key = str(rl_cfg.get("prm_api_key", "") or "")
+                        model_id = str(rl_cfg.get("prm_model", "") or "")
+        except Exception:
+            pass
+
+    api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+    base_url = api_base or os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    model_id = model_id or os.environ.get("PRM_MODEL", "gpt-5.2")
     client_kwargs: dict[str, Any] = {"api_key": api_key}
     client_kwargs["base_url"] = base_url
     client = OpenAI(**client_kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,211 @@
+import asyncio
+import queue
+import threading
+from types import SimpleNamespace
+
+import metaclaw.utils as utils
+from metaclaw.api_server import MetaClawAPIServer
+from metaclaw.config import MetaClawConfig
+
+
+class _FakeStore:
+    def __init__(self, data):
+        self._data = data
+
+    def load(self):
+        return self._data
+
+
+def test_run_llm_uses_explicit_config_for_provider_selection(monkeypatch):
+    monkeypatch.setattr(
+        "metaclaw.config_store.ConfigStore",
+        lambda: _FakeStore({"mode": "skills_only", "llm": {"provider": "bedrock"}}),
+    )
+
+    openai_calls = []
+    bedrock_calls = []
+
+    def fake_openai(messages, config=None):
+        openai_calls.append((messages, config))
+        return "openai"
+
+    def fake_bedrock(messages, config=None):
+        bedrock_calls.append((messages, config))
+        return "bedrock"
+
+    monkeypatch.setattr(utils, "_run_llm_openai", fake_openai)
+    monkeypatch.setattr(utils, "_run_llm_bedrock", fake_bedrock)
+
+    result = utils.run_llm(
+        [{"role": "user", "content": "compress this"}],
+        config=MetaClawConfig(mode="skills_only", llm_provider="custom"),
+    )
+
+    assert result == "openai"
+    assert len(openai_calls) == 1
+    assert bedrock_calls == []
+
+
+def test_run_llm_uses_explicit_skills_only_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        "metaclaw.config_store.ConfigStore",
+        lambda: _FakeStore(
+            {
+                "mode": "rl",
+                "rl": {
+                    "prm_url": "https://wrong.example/v1",
+                    "prm_api_key": "wrong-key",
+                    "prm_model": "wrong-model",
+                },
+            }
+        ),
+    )
+
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=self._create)
+            )
+
+        def _create(self, **kwargs):
+            captured["request_kwargs"] = kwargs
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="compressed"))]
+            )
+
+    monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
+
+    result = utils.run_llm(
+        [{"role": "user", "content": "system prompt"}],
+        config=MetaClawConfig(
+            mode="skills_only",
+            llm_provider="custom",
+            llm_api_base="https://live.example/v1",
+            llm_api_key="live-key",
+            llm_model_id="live-model",
+        ),
+    )
+
+    assert result == "compressed"
+    assert captured["client_kwargs"] == {
+        "api_key": "live-key",
+        "base_url": "https://live.example/v1",
+    }
+    assert captured["request_kwargs"]["model"] == "live-model"
+
+
+def test_run_llm_uses_explicit_rl_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        "metaclaw.config_store.ConfigStore",
+        lambda: _FakeStore(
+            {
+                "mode": "skills_only",
+                "llm": {
+                    "api_base": "https://wrong.example/v1",
+                    "api_key": "wrong-key",
+                    "model_id": "wrong-model",
+                },
+            }
+        ),
+    )
+
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=self._create)
+            )
+
+        def _create(self, **kwargs):
+            captured["request_kwargs"] = kwargs
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="compressed"))]
+            )
+
+    monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
+
+    result = utils.run_llm(
+        [{"role": "user", "content": "judge this"}],
+        config=MetaClawConfig(
+            mode="rl",
+            prm_provider="openai",
+            prm_url="https://judge.example/v1",
+            prm_api_key="judge-key",
+            prm_model="judge-model",
+        ),
+    )
+
+    assert result == "compressed"
+    assert captured["client_kwargs"] == {
+        "api_key": "judge-key",
+        "base_url": "https://judge.example/v1",
+    }
+    assert captured["request_kwargs"]["model"] == "judge-model"
+
+
+def test_handle_request_falls_back_to_raw_system_prompt(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        MetaClawAPIServer,
+        "_load_tokenizer",
+        lambda self: None,
+    )
+
+    config = MetaClawConfig(
+        mode="skills_only",
+        claw_type="openclaw",
+        llm_provider="custom",
+        llm_api_base="https://live.example/v1",
+        llm_api_key="live-key",
+        llm_model_id="live-model",
+        record_enabled=False,
+        record_dir=str(tmp_path),
+    )
+    server = MetaClawAPIServer(
+        config=config,
+        output_queue=queue.Queue(),
+        submission_enabled=threading.Event(),
+    )
+
+    def fail_run_llm(messages, config=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("metaclaw.api_server.run_llm", fail_run_llm)
+
+    forwarded = {}
+
+    async def fake_forward(self, body):
+        forwarded["body"] = body
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "ok",
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(MetaClawAPIServer, "_forward_to_llm", fake_forward)
+
+    result = asyncio.run(
+        server._handle_request(
+            body={
+                "messages": [
+                    {"role": "system", "content": "raw system prompt"},
+                    {"role": "user", "content": "hello"},
+                ]
+            },
+            session_id="session-1",
+            turn_type="main",
+            session_done=False,
+        )
+    )
+
+    assert forwarded["body"]["messages"][0]["content"] == "raw system prompt"
+    assert result["response"]["choices"][0]["message"]["content"] == "ok"


### PR DESCRIPTION
## Summary
- make prompt-compression helper calls use the live runtime config instead of being overwritten by the default on-disk config
- fall back to the raw system prompt when compression fails so custom providers do not turn requests into 500s
- add regression tests for skills-only and RL config precedence plus the compression fallback path
- document that `llm.api_base` should point to the full OpenAI-compatible base URL, typically ending in `/v1`

## Testing
- `python -m pytest -q tests/test_utils.py tests/test_launcher.py tests/test_sdk_backend.py tests/test_openclaw_env_rollout.py`
- `python -m compileall -q metaclaw`
