### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/metaclaw/setup_wizard.py
+++ b/metaclaw/setup_wizard.py
@@ -25,7 +25,7 @@ _PROVIDER_PRESETS = {
     },
     "minimax": {
         "api_base": "https://api.minimax.io/v1",
-        "model_id": "MiniMax-M2.5",
+        "model_id": "MiniMax-M2.7",
     },
     "openrouter": {
         "api_base": "https://openrouter.ai/api/v1",


### PR DESCRIPTION
## Summary
- Upgrade MiniMax provider preset default model from M2.5 to M2.7
- MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities

## Changes
- Update `model_id` in MiniMax provider preset from `MiniMax-M2.5` to `MiniMax-M2.7` in `setup_wizard.py`

## Why
MiniMax-M2.7 is the latest flagship model, offering improved reasoning, coding, and overall performance compared to M2.5.

## Testing
- Verified the change is a single-line model ID update
- No logic changes; existing provider routing and API base URL remain unchanged