### PR TITLE
Add daemon start support to the MetaClaw CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
 ```bash
 metaclaw setup              # one-time config wizard
 metaclaw start              # default: madmax mode — skills + scheduled RL training
+metaclaw start --daemon     # run in background, logs -> ~/.metaclaw/metaclaw.log
+metaclaw start --daemon --log-file /tmp/metaclaw.log  # custom daemon log path
 metaclaw start --mode rl    # RL without scheduler (trains immediately on full batch)
 metaclaw start --mode skills_only  # skills only, no RL (no Tinker needed)
 ```
@@ -217,6 +219,8 @@ Configuration lives in `~/.metaclaw/config.yaml`, created by `metaclaw setup`.
 ```
 metaclaw setup                  # Interactive first-time configuration wizard
 metaclaw start                  # Start MetaClaw (default: madmax mode)
+metaclaw start --daemon         # Start MetaClaw in background
+metaclaw start --daemon --log-file /tmp/metaclaw.log  # Custom daemon log path
 metaclaw start --mode rl        # Force RL mode (no scheduler) for this session
 metaclaw start --mode skills_only  # Force skills-only mode for this session
 metaclaw stop                   # Stop a running MetaClaw instance
@@ -224,6 +228,8 @@ metaclaw status                 # Check proxy health, running mode, and schedule
 metaclaw config show            # View current configuration
 metaclaw config KEY VALUE       # Set a config value
 ```
+
+When you start MetaClaw with `--daemon`, the command waits until the local proxy becomes healthy before returning. Use `metaclaw status` to verify readiness and `metaclaw stop` to stop the background process.
 
 <details>
 <summary><b>Full config reference (click to expand)</b></summary>

--- a/metaclaw/__main__.py
+++ b/metaclaw/__main__.py
@@ -1,0 +1,5 @@
+from .cli import metaclaw
+
+
+if __name__ == "__main__":
+    metaclaw()

--- a/metaclaw/cli.py
+++ b/metaclaw/cli.py
@@ -12,7 +12,9 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import sys
+from pathlib import Path
 
 try:
     import click
@@ -21,6 +23,187 @@ except ImportError:
     sys.exit(1)
 
 from .config_store import CONFIG_FILE, ConfigStore
+from . import runtime_state
+
+
+def _default_daemon_log_path() -> Path:
+    return Path.home() / ".metaclaw" / "metaclaw.log"
+
+
+def _effective_proxy_port(config_store: ConfigStore, override_port: int | None) -> int:
+    if override_port:
+        return override_port
+    return int(config_store.get("proxy.port") or 30000)
+
+
+def _is_process_alive(pid: int) -> bool:
+    return runtime_state.process_alive(pid)
+
+
+def _read_pid() -> int | None:
+    return runtime_state.read_pid()
+
+
+def _clear_pid():
+    runtime_state.clear_pid()
+
+
+def _clear_pid_if_matches(pid: int):
+    runtime_state.clear_pid_if_matches(pid)
+
+
+def _healthz_ready(port: int, timeout: float = 0.5) -> bool:
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/healthz", timeout=timeout) as resp:
+            if resp.status != 200:
+                return False
+            payload = json.loads(resp.read().decode("utf-8"))
+            return payload.get("ok") is True
+    except Exception:
+        return False
+
+
+def _ensure_daemon_not_running():
+    pid = _read_pid()
+    if pid is None:
+        return
+
+    if not _is_process_alive(pid):
+        _clear_pid()
+        return
+
+    raise click.ClickException(
+        f"MetaClaw is already running (PID={pid}). "
+        "Use 'metaclaw status' to inspect it or 'metaclaw stop' before starting a new daemon."
+    )
+
+
+def _wait_for_daemon_ready(proc, port: int, log_path: Path, timeout_s: float = 15.0):
+    import time
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        returncode = proc.poll()
+        if returncode is not None:
+            raise click.ClickException(
+                f"MetaClaw daemon exited with code {returncode}. Check logs: {log_path}"
+            )
+        if _healthz_ready(port):
+            return
+        time.sleep(0.2)
+
+    raise click.ClickException(
+        "MetaClaw daemon did not become healthy in time. "
+        f"Check logs: {log_path}"
+    )
+
+
+def _build_session_override_store(
+    config_store: ConfigStore,
+    mode: str | None,
+    port: int | None,
+) -> tuple[ConfigStore, Path | None]:
+    if not mode and not port:
+        return config_store, None
+
+    from .config_store import ConfigStore as _CS
+    import tempfile
+    import yaml
+
+    data = config_store.load()
+    if mode:
+        data["mode"] = mode
+    if port:
+        data.setdefault("proxy", {})["port"] = port
+
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    )
+    try:
+        yaml.dump(data, tmp)
+    finally:
+        tmp.close()
+    tmp_path = Path(tmp.name)
+    return _CS(config_file=tmp_path), tmp_path
+
+
+def _spawn_daemon_process(
+    mode: str | None,
+    port: int | None,
+    log_file: str | None,
+    effective_port: int,
+) -> tuple[int, Path]:
+    import os
+    import signal
+    import subprocess
+
+    log_path = Path(log_file).expanduser() if log_file else _default_daemon_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with runtime_state.daemon_start_lock():
+            _ensure_daemon_not_running()
+
+            cmd = [sys.executable, "-m", "metaclaw", "start"]
+            if mode:
+                cmd.extend(["--mode", mode])
+            if port:
+                cmd.extend(["--port", str(port)])
+
+            with log_path.open("ab") as log_handle:
+                child_env = os.environ.copy()
+                child_env["METACLAW_RUNTIME_KIND"] = "daemon"
+                child_env["METACLAW_RUNTIME_LOG_PATH"] = str(log_path)
+                popen_kwargs = {
+                    "stdin": subprocess.DEVNULL,
+                    "stdout": log_handle,
+                    "stderr": subprocess.STDOUT,
+                    "close_fds": True,
+                    "env": child_env,
+                }
+                if os.name == "nt":
+                    creationflags = (
+                        getattr(subprocess, "DETACHED_PROCESS", 0)
+                        | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                    )
+                    if creationflags:
+                        popen_kwargs["creationflags"] = creationflags
+                else:
+                    popen_kwargs["start_new_session"] = True
+                proc = subprocess.Popen(cmd, **popen_kwargs)
+
+            try:
+                _wait_for_daemon_ready(proc, effective_port, log_path)
+            except Exception:
+                try:
+                    if proc.poll() is None:
+                        if os.name == "nt":
+                            proc.terminate()
+                        else:
+                            os.killpg(proc.pid, signal.SIGTERM)
+                        try:
+                            proc.wait(timeout=5)
+                        except subprocess.TimeoutExpired:
+                            if os.name == "nt":
+                                proc.kill()
+                            else:
+                                os.killpg(proc.pid, signal.SIGKILL)
+                            proc.wait(timeout=5)
+                except Exception:
+                    pass
+
+                _clear_pid_if_matches(proc.pid)
+                raise
+
+            return proc.pid, log_path
+    except RuntimeError as exc:
+        owner_pid = exc.args[0] if exc.args else "?"
+        raise click.ClickException(
+            f"Another 'metaclaw start --daemon' is already in progress (PID={owner_pid}). "
+            "Wait for it to finish or stop that process before retrying."
+        ) from None
 
 
 @click.group()
@@ -48,7 +231,20 @@ def setup():
     default=None,
     help="Override proxy port for this session.",
 )
-def start(mode: str | None, port: int | None):
+@click.option(
+    "--daemon",
+    "-d",
+    is_flag=True,
+    default=False,
+    help="Run MetaClaw in the background.",
+)
+@click.option(
+    "--log-file",
+    type=click.Path(dir_okay=False, path_type=str),
+    default=None,
+    help="Log file used with --daemon (default: ~/.metaclaw/metaclaw.log).",
+)
+def start(mode: str | None, port: int | None, daemon: bool, log_file: str | None):
     """Start MetaClaw (proxy + optional RL training)."""
     import asyncio
     from .log_color import setup_logging
@@ -63,22 +259,20 @@ def start(mode: str | None, port: int | None):
         )
         sys.exit(1)
 
-    # Session-level overrides (don't persist)
-    if mode or port:
-        data = cs.load()
-        if mode:
-            data["mode"] = mode
-        if port:
-            data.setdefault("proxy", {})["port"] = port
-        # Use an in-memory store for this session
-        from .config_store import ConfigStore as _CS
-        import tempfile, os, yaml
-        tmp = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+    if daemon:
+        pid, log_path = _spawn_daemon_process(
+            mode,
+            port,
+            log_file,
+            effective_port=_effective_proxy_port(cs, port),
         )
-        yaml.dump(data, tmp)
-        tmp.close()
-        cs = _CS(config_file=__import__("pathlib").Path(tmp.name))
+        click.echo(
+            f"MetaClaw started in background (PID={pid}). Logs: {log_path}. "
+            "Use 'metaclaw status' to check health and 'metaclaw stop' to stop it."
+        )
+        return
+
+    cs, temp_config_path = _build_session_override_store(cs, mode, port)
 
     from .launcher import MetaClawLauncher
     launcher = MetaClawLauncher(cs)
@@ -87,6 +281,9 @@ def start(mode: str | None, port: int | None):
     except KeyboardInterrupt:
         click.echo("\nInterrupted — stopping MetaClaw.")
         launcher.stop()
+    finally:
+        if temp_config_path is not None:
+            temp_config_path.unlink(missing_ok=True)
 
 
 @metaclaw.command()
@@ -125,25 +322,17 @@ def status():
 
     try:
         pid = int(pid_file.read_text().strip())
-        os.kill(pid, 0)  # check if process exists
+        os.kill(pid, 0)
     except (ProcessLookupError, ValueError):
         click.echo("MetaClaw: not running (stale PID file)")
         pid_file.unlink(missing_ok=True)
         return
 
-    # Try health check
     cs = ConfigStore()
-    port = cs.get("proxy.port") or 30000
-    try:
-        import urllib.request
-        with urllib.request.urlopen(
-            f"http://localhost:{port}/healthz", timeout=2
-        ) as resp:
-            healthy = resp.status == 200
-    except Exception:
-        healthy = False
+    port = int(cs.get("proxy.port") or 30000)
+    mode = str(cs.get("mode") or "?")
 
-    mode = cs.get("mode") or "?"
+    healthy = _healthz_ready(port, timeout=2.0)
     if healthy:
         click.echo(f"MetaClaw: running  (PID={pid}, mode={mode}, proxy=:{port})")
     else:
@@ -155,9 +344,9 @@ def status():
         try:
             import json
             sched = json.loads(state_file.read_text())
-            state_val  = sched.get("state", "?")
-            sleep_win  = sched.get("sleep_window", "?")
-            idle_min   = sched.get("idle_threshold_minutes", "?")
+            state_val = sched.get("state", "?")
+            sleep_win = sched.get("sleep_window", "?")
+            idle_min = sched.get("idle_threshold_minutes", "?")
             updated_at = sched.get("updated_at", "?")
             click.echo(
                 f"scheduler:  state={state_val}  "

--- a/metaclaw/runtime_state.py
+++ b/metaclaw/runtime_state.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def _state_dir() -> Path:
+    return Path.home() / ".metaclaw"
+
+
+def pid_file_path() -> Path:
+    return _state_dir() / "metaclaw.pid"
+
+
+def daemon_start_lock_path() -> Path:
+    return _state_dir() / "daemon_start.lock"
+
+
+def process_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return False
+
+
+def _coerce_pid(value: Any) -> int | None:
+    try:
+        pid = int(value)
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def read_pid() -> int | None:
+    try:
+        pid = _coerce_pid(pid_file_path().read_text(encoding="utf-8").strip())
+    except FileNotFoundError:
+        return None
+    if pid is None:
+        pid_file_path().unlink(missing_ok=True)
+        return None
+    return pid
+
+
+def write_pid(pid: int):
+    path = pid_file_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _write_text_atomic(path, str(pid))
+
+
+def clear_pid():
+    pid_file_path().unlink(missing_ok=True)
+
+
+def clear_pid_if_matches(pid: int):
+    if read_pid() == pid:
+        clear_pid()
+
+
+def _write_text_atomic(path: Path, text: str):
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as handle:
+            tmp_path = Path(handle.name)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+@contextmanager
+def daemon_start_lock():
+    path = daemon_start_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    owner_pid = os.getpid()
+
+    while True:
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            try:
+                holder = _coerce_pid(path.read_text(encoding="utf-8").strip())
+            except FileNotFoundError:
+                continue
+
+            if holder is None or not process_alive(holder):
+                path.unlink(missing_ok=True)
+                continue
+
+            raise RuntimeError(holder)
+
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(str(owner_pid))
+                handle.flush()
+                os.fsync(handle.fileno())
+            break
+        except Exception:
+            path.unlink(missing_ok=True)
+            raise
+
+    try:
+        yield
+    finally:
+        try:
+            holder = _coerce_pid(path.read_text(encoding="utf-8").strip())
+        except FileNotFoundError:
+            return
+        except Exception:
+            path.unlink(missing_ok=True)
+            return
+
+        if holder == owner_pid or holder is None:
+            path.unlink(missing_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,352 @@
+import os
+import signal
+import subprocess
+
+import click
+from click.testing import CliRunner
+
+from metaclaw import cli
+
+
+def test_start_daemon_spawns_detached_child(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    class FakeConfigStore:
+        def exists(self):
+            return True
+
+        def get(self, key):
+            assert key == "proxy.port"
+            return 30000
+
+    class FakeProcess:
+        pid = 43210
+
+        def poll(self):
+            return None
+
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setattr(cli, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr(cli, "_wait_for_daemon_ready", lambda proc, port, log_path: None)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.metaclaw, ["start", "--daemon"])
+
+    assert result.exit_code == 0
+    assert "MetaClaw started in background (PID=43210)." in result.output
+    assert "metaclaw status" in result.output
+    assert "metaclaw stop" in result.output
+    assert captured["cmd"] == [cli.sys.executable, "-m", "metaclaw", "start"]
+    assert captured["kwargs"]["stdin"] == subprocess.DEVNULL
+    assert captured["kwargs"]["stderr"] == subprocess.STDOUT
+    assert captured["kwargs"]["close_fds"] is True
+    assert captured["kwargs"]["stdout"].name.endswith("metaclaw.log")
+    assert captured["kwargs"]["env"]["METACLAW_RUNTIME_KIND"] == "daemon"
+    assert captured["kwargs"]["env"]["METACLAW_RUNTIME_LOG_PATH"].endswith("metaclaw.log")
+    if os.name == "nt":
+        assert captured["kwargs"]["creationflags"] != 0
+    else:
+        assert captured["kwargs"]["start_new_session"] is True
+
+
+def test_start_daemon_propagates_mode_port_and_log_file_without_parent_override_file(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    class FakeConfigStore:
+        def exists(self):
+            return True
+
+    class FakeProcess:
+        pid = 43211
+
+        def poll(self):
+            return None
+
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProcess()
+
+    monkeypatch.setattr(cli, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    monkeypatch.setattr(cli, "_wait_for_daemon_ready", lambda proc, port, log_path: None)
+    monkeypatch.setattr(
+        cli,
+        "_build_session_override_store",
+        lambda config_store, mode, port: (_ for _ in ()).throw(
+            AssertionError("daemon path should not build an override config file")
+        ),
+    )
+
+    runner = CliRunner()
+    log_path = tmp_path / "custom.log"
+    result = runner.invoke(
+        cli.metaclaw,
+        [
+            "start",
+            "--daemon",
+            "--mode",
+            "skills_only",
+            "--port",
+            "31001",
+            "--log-file",
+            str(log_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["cmd"] == [
+        cli.sys.executable,
+        "-m",
+        "metaclaw",
+        "start",
+        "--mode",
+        "skills_only",
+        "--port",
+        "31001",
+    ]
+    assert str(log_path) in result.output
+
+
+def test_wait_for_daemon_ready_returns_after_health_check(monkeypatch, tmp_path):
+    class FakeProcess:
+        def poll(self):
+            return None
+
+    checks = iter([False, True])
+    monkeypatch.setattr(cli, "_healthz_ready", lambda port, timeout=0.5: next(checks))
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    cli._wait_for_daemon_ready(FakeProcess(), 30000, tmp_path / "metaclaw.log", timeout_s=1.0)
+
+
+def test_wait_for_daemon_ready_raises_when_process_exits(monkeypatch, tmp_path):
+    class FakeProcess:
+        def poll(self):
+            return 23
+
+    monkeypatch.setattr(cli, "_healthz_ready", lambda port, timeout=0.5: False)
+
+    try:
+        cli._wait_for_daemon_ready(FakeProcess(), 30000, tmp_path / "metaclaw.log", timeout_s=0.2)
+    except click.ClickException as exc:
+        assert "exited with code 23" in str(exc)
+        assert "metaclaw.log" in str(exc)
+    else:
+        raise AssertionError("expected ClickException when daemon exits early")
+
+
+def test_spawn_daemon_process_terminates_child_and_cleans_runtime_files_on_timeout(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    class FakeProcess:
+        pid = 43212
+
+        def __init__(self):
+            self._alive = True
+            self.terminated = False
+            self.waits = []
+
+        def poll(self):
+            return None if self._alive else 0
+
+        def wait(self, timeout=None):
+            self.waits.append(timeout)
+            self._alive = False
+            return 0
+
+    proc = FakeProcess()
+    cleared = []
+
+    monkeypatch.setattr(cli, "_ensure_daemon_not_running", lambda: None)
+    monkeypatch.setattr(
+        "metaclaw.runtime_state.daemon_start_lock",
+        lambda: __import__("contextlib").nullcontext(),
+    )
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda cmd, **kwargs: proc,
+    )
+    monkeypatch.setattr(
+        cli,
+        "_wait_for_daemon_ready",
+        lambda proc_, port, log_path: (_ for _ in ()).throw(click.ClickException("timeout")),
+    )
+    monkeypatch.setattr(cli, "_clear_pid_if_matches", lambda pid: cleared.append(pid))
+    killpg_calls = []
+    monkeypatch.setattr("os.killpg", lambda pid, sig: killpg_calls.append((pid, sig)))
+
+    try:
+        cli._spawn_daemon_process(None, None, None, effective_port=30000)
+    except click.ClickException as exc:
+        assert "timeout" in str(exc)
+    else:
+        raise AssertionError("expected ClickException when daemon startup times out")
+
+    assert killpg_calls == [(43212, signal.SIGTERM)]
+    assert proc.waits == [5]
+    assert cleared == [43212]
+
+
+def test_start_cleans_up_temp_override_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    class FakeConfigStore:
+        def exists(self):
+            return True
+
+    temp_config = tmp_path / "session-override.yaml"
+    temp_config.write_text("mode: skills_only\n", encoding="utf-8")
+
+    class FakeLauncher:
+        def __init__(self, config_store):
+            self.config_store = config_store
+
+        async def start(self):
+            return None
+
+        def stop(self):
+            return None
+
+    monkeypatch.setattr(cli, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr(cli, "_build_session_override_store", lambda cs, mode, port: (cs, temp_config))
+    monkeypatch.setattr("metaclaw.launcher.MetaClawLauncher", FakeLauncher)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.metaclaw, ["start", "--mode", "skills_only"])
+
+    assert result.exit_code == 0
+    assert not temp_config.exists()
+
+
+def test_ensure_daemon_not_running_rejects_live_pid(monkeypatch):
+    monkeypatch.setattr(cli, "_read_pid", lambda: 12345)
+    monkeypatch.setattr(cli, "_is_process_alive", lambda pid: True)
+
+    try:
+        cli._ensure_daemon_not_running()
+    except click.ClickException as exc:
+        assert "already running" in str(exc)
+        assert "12345" in str(exc)
+    else:
+        raise AssertionError("expected ClickException when an active daemon already exists")
+
+
+def test_ensure_daemon_not_running_clears_stale_pid(monkeypatch):
+    cleared = []
+
+    monkeypatch.setattr(cli, "_read_pid", lambda: 12345)
+    monkeypatch.setattr(cli, "_is_process_alive", lambda pid: False)
+    monkeypatch.setattr(cli, "_clear_pid", lambda: cleared.append(True))
+
+    cli._ensure_daemon_not_running()
+
+    assert cleared == [True]
+
+
+def test_status_uses_configured_mode_and_port(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    state_dir = tmp_path / ".metaclaw"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "metaclaw.pid").write_text("54321", encoding="utf-8")
+
+    calls = []
+    monkeypatch.setattr("os.kill", lambda pid, sig: calls.append((pid, sig)))
+    monkeypatch.setattr(cli, "_healthz_ready", lambda port, timeout=2.0: True)
+
+    class FakeConfigStore:
+        def get(self, key):
+            if key == "proxy.port":
+                return 31001
+            if key == "mode":
+                return "skills_only"
+            raise AssertionError(f"unexpected key: {key}")
+
+    monkeypatch.setattr(cli, "ConfigStore", FakeConfigStore)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.metaclaw, ["status"])
+
+    assert result.exit_code == 0
+    assert "PID=54321" in result.output
+    assert "mode=skills_only" in result.output
+    assert "proxy=:31001" in result.output
+    assert calls == [(54321, 0)]
+
+
+def test_stop_removes_pid_file_after_signal(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    state_dir = tmp_path / ".metaclaw"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    pid_path = state_dir / "metaclaw.pid"
+    pid_path.write_text("54321", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr("os.kill", lambda pid, sig: calls.append((pid, sig)))
+
+    runner = CliRunner()
+    result = runner.invoke(cli.metaclaw, ["stop"])
+
+    assert result.exit_code == 0
+    assert calls == [(54321, signal.SIGTERM)]
+    assert "Sent SIGTERM to PID 54321." in result.output
+    assert not pid_path.exists()
+
+
+def test_stop_cleans_pid_file_when_pid_is_stale(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    state_dir = tmp_path / ".metaclaw"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    pid_path = state_dir / "metaclaw.pid"
+    pid_path.write_text("54321", encoding="utf-8")
+
+    def fake_kill(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr("os.kill", fake_kill)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.metaclaw, ["stop"])
+
+    assert result.exit_code == 0
+    assert not pid_path.exists()
+    assert "cleaning up stale PID file" in result.output
+
+
+def test_start_daemon_rejects_concurrent_start_lock(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    class FakeConfigStore:
+        def exists(self):
+            return True
+
+        def get(self, key):
+            assert key == "proxy.port"
+            return 30000
+
+    @__import__("contextlib").contextmanager
+    def fake_lock():
+        raise RuntimeError(98765)
+        yield
+
+    monkeypatch.setattr(cli, "ConfigStore", FakeConfigStore)
+    monkeypatch.setattr("metaclaw.runtime_state.daemon_start_lock", fake_lock)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.metaclaw, ["start", "--daemon"])
+
+    assert result.exit_code != 0
+    assert "already in progress" in result.output
+    assert "98765" in result.output

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -1,0 +1,62 @@
+from metaclaw import runtime_state
+
+
+def test_read_pid_clears_non_positive_pid(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    pid_path = runtime_state.pid_file_path()
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text("0", encoding="utf-8")
+
+    assert runtime_state.read_pid() is None
+    assert not pid_path.exists()
+
+
+def test_process_alive_treats_permission_error_as_live(monkeypatch):
+    def fake_kill(pid, sig):
+        raise PermissionError
+
+    monkeypatch.setattr("os.kill", fake_kill)
+
+    assert runtime_state.process_alive(12345) is True
+
+
+def test_clear_pid_if_matches_only_clears_matching_pid(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    pid_path = runtime_state.pid_file_path()
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text("12345", encoding="utf-8")
+
+    runtime_state.clear_pid_if_matches(12345)
+
+    assert not pid_path.exists()
+
+
+def test_daemon_start_lock_reclaims_stale_holder(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    lock_path = runtime_state.daemon_start_lock_path()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("99999", encoding="utf-8")
+    monkeypatch.setattr("os.getpid", lambda: 12345)
+    monkeypatch.setattr(runtime_state, "process_alive", lambda pid: pid == 12345)
+
+    with runtime_state.daemon_start_lock():
+        assert lock_path.exists()
+        assert lock_path.read_text(encoding="utf-8").strip() == "12345"
+
+    assert not lock_path.exists()
+
+
+def test_daemon_start_lock_rejects_live_holder(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    lock_path = runtime_state.daemon_start_lock_path()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("54321", encoding="utf-8")
+    monkeypatch.setattr(runtime_state, "process_alive", lambda pid: pid == 54321)
+
+    try:
+        with runtime_state.daemon_start_lock():
+            raise AssertionError("lock acquisition should have failed")
+    except RuntimeError as exc:
+        assert exc.args == (54321,)
+    else:
+        raise AssertionError("expected RuntimeError for live daemon start lock holder")


### PR DESCRIPTION
## Summary
- add `metaclaw start --daemon` with optional `--log-file`
- launch the daemon in a detached child process and wait for `/healthz` before returning
- add lightweight runtime helpers and regression tests for daemon startup paths

## Testing
- `pytest -q tests/test_cli.py tests/test_runtime_state.py tests/test_launcher.py`

## Notes
- local docs notes were intentionally left out of this PR