### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from metaclaw.config_store import ConfigStore
-from metaclaw.setup_wizard import SetupWizard
+from metaclaw.setup_wizard import SetupWizard, _PROVIDER_PRESETS
 
 
 def test_setup_wizard_preserves_existing_proxy_settings(monkeypatch, tmp_path: Path):
@@ -79,3 +79,52 @@ def test_setup_wizard_preserves_existing_proxy_settings(monkeypatch, tmp_path: P
     assert saved["proxy"]["host"] == "127.0.0.1"
     assert saved["proxy"]["api_key"] == "proxy-key"
     assert saved["proxy"]["trusted_local"] is True
+
+
+def test_minimax_preset_defaults_to_m27():
+    """MiniMax preset should default to MiniMax-M2.7."""
+    preset = _PROVIDER_PRESETS["minimax"]
+    assert preset["model_id"] == "MiniMax-M2.7"
+    assert preset["api_base"] == "https://api.minimax.io/v1"
+
+
+def test_minimax_provider_fresh_setup(monkeypatch, tmp_path: Path):
+    """Fresh setup with minimax provider should default to MiniMax-M2.7."""
+    config_path = tmp_path / "config.yaml"
+    skills_dir = tmp_path / "skills"
+    store = ConfigStore(config_file=config_path)
+    # No existing config — simulates a fresh setup
+
+    monkeypatch.setattr("metaclaw.setup_wizard.ConfigStore", lambda: store)
+
+    def fake_prompt_choice(msg, choices, default=""):
+        if "agent" in msg.lower():
+            return "openclaw"
+        if msg == "Operating mode":
+            return "skills_only"
+        if msg == "LLM provider":
+            return "minimax"
+        raise AssertionError(f"Unexpected choice prompt: {msg}")
+
+    def fake_prompt(msg, default="", hide=False):
+        if msg == "Skills directory":
+            return str(skills_dir)
+        return default
+
+    def fake_prompt_bool(msg, default=False):
+        return default
+
+    def fake_prompt_int(msg, default=0):
+        return default
+
+    monkeypatch.setattr("metaclaw.setup_wizard._prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("metaclaw.setup_wizard._prompt", fake_prompt)
+    monkeypatch.setattr("metaclaw.setup_wizard._prompt_bool", fake_prompt_bool)
+    monkeypatch.setattr("metaclaw.setup_wizard._prompt_int", fake_prompt_int)
+
+    SetupWizard().run()
+
+    saved = store.load()
+    assert saved["llm"]["provider"] == "minimax"
+    assert saved["llm"]["model_id"] == "MiniMax-M2.7"
+    assert saved["llm"]["api_base"] == "https://api.minimax.io/v1"


### PR DESCRIPTION
## Summary
- Upgrade MiniMax preset default model from M2.5 to M2.7
- Add unit tests for MiniMax preset validation and fresh setup wizard flow
- All previous providers remain available as alternatives

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.

## Changes
- `metaclaw/setup_wizard.py`: Update `model_id` in minimax preset from `MiniMax-M2.5` to `MiniMax-M2.7`
- `tests/test_setup_wizard.py`: Add `test_minimax_preset_defaults_to_m27` and `test_minimax_provider_fresh_setup` tests

## Testing
- Unit tests added and passing
- Verified preset values and wizard flow produce correct MiniMax-M2.7 default