### PR TITLE
Add Novita AI as LLM provider

### DIFF
--- a/metaclaw/setup_wizard.py
+++ b/metaclaw/setup_wizard.py
@@ -27,6 +27,10 @@ _PROVIDER_PRESETS = {
         "api_base": "https://api.minimax.io/v1",
         "model_id": "MiniMax-M2.7",
     },
+    "novita": {
+        "api_base": "https://api.novita.ai/openai",
+        "model_id": "moonshotai/kimi-k2.5",
+    },
     "openrouter": {
         "api_base": "https://openrouter.ai/api/v1",
         "model_id": "google/gemini-2.5-pro",
@@ -128,7 +132,7 @@ class SetupWizard:
         current_provider = current_llm.get("provider", "custom")
         provider = _prompt_choice(
             "LLM provider",
-            ["kimi", "qwen", "openai", "minimax", "openrouter", "bedrock", "custom"],
+            ["kimi", "qwen", "openai", "minimax", "novita", "openrouter", "bedrock", "custom"],
             default=current_provider,
         )
         preset = _PROVIDER_PRESETS[provider]

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -81,6 +81,54 @@ def test_setup_wizard_preserves_existing_proxy_settings(monkeypatch, tmp_path: P
     assert saved["proxy"]["trusted_local"] is True
 
 
+def test_novita_preset_defaults():
+    """Novita preset should use the OpenAI-compatible endpoint and kimi-k2.5."""
+    preset = _PROVIDER_PRESETS["novita"]
+    assert preset["api_base"] == "https://api.novita.ai/openai"
+    assert preset["model_id"] == "moonshotai/kimi-k2.5"
+
+
+def test_novita_provider_fresh_setup(monkeypatch, tmp_path: Path):
+    """Fresh setup with novita provider should save the correct endpoint and model."""
+    config_path = tmp_path / "config.yaml"
+    skills_dir = tmp_path / "skills"
+    store = ConfigStore(config_file=config_path)
+
+    monkeypatch.setattr("metaclaw.setup_wizard.ConfigStore", lambda: store)
+
+    def fake_prompt_choice(msg, choices, default=""):
+        if "agent" in msg.lower():
+            return "openclaw"
+        if msg == "Operating mode":
+            return "skills_only"
+        if msg == "LLM provider":
+            return "novita"
+        raise AssertionError(f"Unexpected choice prompt: {msg}")
+
+    def fake_prompt(msg, default="", hide=False):
+        if msg == "Skills directory":
+            return str(skills_dir)
+        return default
+
+    def fake_prompt_bool(msg, default=False):
+        return default
+
+    def fake_prompt_int(msg, default=0):
+        return default
+
+    monkeypatch.setattr("metaclaw.setup_wizard._prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("metaclaw.setup_wizard._prompt", fake_prompt)
+    monkeypatch.setattr("metaclaw.setup_wizard._prompt_bool", fake_prompt_bool)
+    monkeypatch.setattr("metaclaw.setup_wizard._prompt_int", fake_prompt_int)
+
+    SetupWizard().run()
+
+    saved = store.load()
+    assert saved["llm"]["provider"] == "novita"
+    assert saved["llm"]["model_id"] == "moonshotai/kimi-k2.5"
+    assert saved["llm"]["api_base"] == "https://api.novita.ai/openai"
+
+
 def test_minimax_preset_defaults_to_m27():
     """MiniMax preset should default to MiniMax-M2.7."""
     preset = _PROVIDER_PRESETS["minimax"]


### PR DESCRIPTION
## Summary

- Adds `novita` to `_PROVIDER_PRESETS` in `setup_wizard.py` with the OpenAI-compatible endpoint (`https://api.novita.ai/openai`) and default model `moonshotai/kimi-k2.5`
- Adds `novita` to the provider selection menu in the setup wizard
- Adds two tests: preset value validation and end-to-end fresh-setup flow

## Details

Novita AI exposes an OpenAI-compatible API, so it routes through the existing OpenAI forwarding path in `api_server.py` with no additional changes required. Users configure it the same way as any other OpenAI-compatible provider: set `NOVITA_API_KEY` (or enter it during `metaclaw setup`) and the endpoint is pre-filled automatically.

## Test plan

- [ ] `pytest tests/test_setup_wizard.py::test_novita_preset_defaults` passes
- [ ] `pytest tests/test_setup_wizard.py::test_novita_provider_fresh_setup` passes
- [ ] `metaclaw setup` shows `novita` in the provider selection list